### PR TITLE
Add SymmetricEncryptionManager and deprecate AES class

### DIFF
--- a/MayMeow.Cryptography.Test/SymmetricEncryptionManagerTests.cs
+++ b/MayMeow.Cryptography.Test/SymmetricEncryptionManagerTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MayMeow.Cryptography.Security;
+using System;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace MayMeow.Cryptography.Test
+{
+    [TestClass]
+    public class SymmetricEncryptionManagerTests
+    {
+        [TestMethod]
+        public void EncryptData_ValidInput_ReturnsEncryptedData()
+        {
+            // Arrange  
+            string password = SymmetricEncryptionManager.GenerateRandomPassword();
+            string dataToEncrypt = "TestData";
+
+            // Act  
+            var encryptedData = SymmetricEncryptionManager.encryptData(password, dataToEncrypt);
+
+            // Assert  
+            Assert.IsNotNull(encryptedData);
+            Assert.IsNotNull(encryptedData.CipherData);
+            Assert.IsNotNull(encryptedData.Salt);
+            Assert.IsNotNull(encryptedData.IV);
+            Assert.AreEqual(100000, encryptedData.Iterations);
+        }
+
+        [TestMethod]
+        public void DecryptData_ValidInput_ReturnsOriginalData()
+        {
+            // Arrange  
+            string password = SymmetricEncryptionManager.GenerateRandomPassword();
+            string dataToEncrypt = "TestData";
+            var encryptedData = SymmetricEncryptionManager.encryptData(password, dataToEncrypt);
+
+            // Act  
+            var decryptedData = SymmetricEncryptionManager.decryptData(encryptedData, password);
+
+            // Assert  
+            Assert.AreEqual(dataToEncrypt, decryptedData);
+        }
+
+        [TestMethod]
+        public void EncryptData_NullPassword_ThrowsArgumentException()
+        {
+            // Arrange  
+            string password = null;
+            string dataToEncrypt = "TestData";
+
+            // Act & Assert  
+            var ex = Assert.ThrowsException<ArgumentException>(() => SymmetricEncryptionManager.encryptData(password, dataToEncrypt));
+            Assert.AreEqual("Password cannot be null or empty (Parameter 'password')", ex.Message);
+        }
+
+        [TestMethod]
+        public void DecryptData_NullEncryptedData_ThrowsArgumentNullException()
+        {
+            // Arrange  
+            string password = SymmetricEncryptionManager.GenerateRandomPassword();
+            SymmetricEncryptionManager.EncryptedData encryptedData = null;
+
+            // Act & Assert  
+            var ex = Assert.ThrowsException<ArgumentNullException>(() => SymmetricEncryptionManager.decryptData(encryptedData, password));
+            Assert.AreEqual("Encrypted data cannot be null (Parameter 'encryptedData')", ex.Message);
+        }
+
+        [TestMethod]
+        public void DecryptData_InvalidPassword_ThrowsCryptographicException()
+        {
+            // Arrange  
+            string password = SymmetricEncryptionManager.GenerateRandomPassword();
+            string dataToEncrypt = "TestData";
+            var encryptedData = SymmetricEncryptionManager.encryptData(password, dataToEncrypt);
+            string invalidPassword = "WrongPassword";
+
+            // Act & Assert  
+            Assert.ThrowsException<CryptographicException>(() => SymmetricEncryptionManager.decryptData(encryptedData, invalidPassword));
+        }
+    }
+}

--- a/MayMeow.Cryptography/AES.cs
+++ b/MayMeow.Cryptography/AES.cs
@@ -6,6 +6,12 @@ using System.Text;
 
 namespace MayMeow.Cryptography
 {
+
+    /// <summary>
+    /// AES encryption and decryption class using AesCryptoServiceProvider.
+    /// </summary>
+    /// 
+    [Obsolete("This class is deprecated, se MayMeow.Cryptography.Security.SymmetricEncryptionManager Instead")]
     public class AES
     {
         private SymmetricAlgorithm _Aes;

--- a/MayMeow.Cryptography/Security/SymmetricEncryptionManager.cs
+++ b/MayMeow.Cryptography/Security/SymmetricEncryptionManager.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MayMeow.Cryptography.Security
+{
+    public static class SymmetricEncryptionManager
+    {
+        private const int keySize = 32;
+        private const int IVSize = 16;
+        private const int DefaultIterations = 100000;
+
+        public class EncryptedData
+        {
+            public byte[] CipherData { get; set; }
+            public byte[] Salt { get; set; }
+            public byte[] IV { get; set; }
+            public int Iterations { get; set; }
+        }
+
+        public static EncryptedData encryptData(string password, string DataToEncrypt)
+        {
+            if (string.IsNullOrEmpty(password))
+            {
+                throw new ArgumentException("Password cannot be null or empty", nameof(password));
+            }
+
+            var IV = new byte[IVSize];
+            var salt = new byte[IVSize];
+            RandomNumberGenerator.Fill(IV);
+            RandomNumberGenerator.Fill(salt);
+
+            using (var pbkdf = new Rfc2898DeriveBytes(password, salt, DefaultIterations, HashAlgorithmName.SHA256)) {
+                var derivedKey = pbkdf.GetBytes(keySize);
+
+                using (var aes = Aes.Create())
+                {
+                    aes.Key = derivedKey;
+                    aes.IV = IV;
+                    aes.Mode = CipherMode.CBC;
+                    aes.Padding = PaddingMode.PKCS7;
+
+                    using (var encryptor = aes.CreateEncryptor())
+                    {
+                        var dataBytes = Encoding.UTF8.GetBytes(DataToEncrypt);
+                        var encryptedData = encryptor.TransformFinalBlock(dataBytes, 0, dataBytes.Length);
+
+                        return new EncryptedData
+                        {
+                            CipherData = encryptedData,
+                            Salt = salt,
+                            IV = IV,
+                            Iterations = DefaultIterations
+                        };
+                    }
+                }
+            }
+        }
+
+        public static string decryptData(EncryptedData encryptedData, string password)
+        {
+            if (encryptedData == null)
+            {
+                throw new ArgumentNullException(nameof(encryptedData), "Encrypted data cannot be null");
+            }
+            if (string.IsNullOrEmpty(password))
+            {
+                throw new ArgumentException("Password cannot be null or empty", nameof(password));
+            }
+            using (var pbkdf = new Rfc2898DeriveBytes(password, encryptedData.Salt, encryptedData.Iterations, HashAlgorithmName.SHA256))
+            {
+                var derivedKey = pbkdf.GetBytes(keySize);
+                using (var aes = Aes.Create())
+                {
+                    aes.Key = derivedKey;
+                    aes.IV = encryptedData.IV;
+                    aes.Mode = CipherMode.CBC;
+                    aes.Padding = PaddingMode.PKCS7;
+                    using (var decryptor = aes.CreateDecryptor())
+                    {
+                        var decryptedData = decryptor.TransformFinalBlock(encryptedData.CipherData, 0, encryptedData.CipherData.Length);
+                        return Encoding.UTF8.GetString(decryptedData);
+                    }
+                }
+            }
+        }
+
+        public static string GenerateRandomPassword()
+        {
+            var passwordBytes = new byte[keySize];
+            RandomNumberGenerator.Fill(passwordBytes);
+            return Convert.ToBase64String(passwordBytes);
+        }
+    }
+
+    
+}


### PR DESCRIPTION
Introduced `SymmetricEncryptionManager` for secure AES-based encryption and decryption, replacing the deprecated `AES` class. Implemented cryptographic best practices, including PBKDF2 with SHA-256 and secure random value generation. Added unit tests to validate functionality and ensure reliability. Enhanced code documentation for clarity and maintainability.

closes #9 